### PR TITLE
Updating to new ID approach for paging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ graphResultsPager({
 	query: {
 		entity: '...',
 		selection: {
+			// Note: orderBy DOES NOT WORK due to how the paging is implemented, it is overriden by id 
 			orderBy: '...',
 			orderDirection: 'desc',
 			where: {

--- a/example.js
+++ b/example.js
@@ -21,8 +21,6 @@ graphResultsPager({
 	query: {
 		entity: 'synthExchanges',
 		selection: {
-			orderBy: 'timestamp',
-			orderDirection: 'desc',
 			where: {
 				timestamp_gt: Math.floor(Date.now() / 1e3) - 3600 * 24, // one day ago
 			},

--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ const pageResults = ({ api, query: { entity, selection = {}, properties = [] }, 
 
 		const first = MAX_PAGE_SIZE;
 
+		if(!properties.includes('id')) {
+			properties.push('id');
+		};
+
 		// mix the page size and skip fields into the selection object
 		const selectionObj = Object.assign({}, selection, {
 			first,

--- a/index.js
+++ b/index.js
@@ -22,19 +22,23 @@ const pageResults = ({ api, query: { entity, selection = {}, properties = [] }, 
 	// Note: this approach will call each page in linear order, ensuring it stops as soon as all results
 	// are fetched. This could be sped up with a number of requests done in parallel, stopping as soon as any return
 	// empty. - JJM
-	const runner = ({ skip }) => {
+	const runner = ({ lastId }) => {
 		const propToString = obj =>
 			Object.entries(obj)
 				.filter(([, value]) => typeof value !== 'undefined')
 				.map(([key, value]) => `${key}:${typeof value === 'object' ? '{' + propToString(value) + '}' : value}`)
 				.join(',');
 
-		const first = skip + pageSize > max ? max % pageSize : pageSize;
+		const first = MAX_PAGE_SIZE;
 
 		// mix the page size and skip fields into the selection object
 		const selectionObj = Object.assign({}, selection, {
 			first,
-			skip,
+			orderBy: 'id',
+			where: { 
+				...selection.where, 
+				...lastId ? {id_gt: `\\"${lastId}\\"`} : {} 
+			},
 		});
 
 		const body = `{"query":"{${entity}(${propToString(selectionObj)}){${properties.join(',')}}}", "variables": null}`;
@@ -42,7 +46,7 @@ const pageResults = ({ api, query: { entity, selection = {}, properties = [] }, 
 		// support query logging in nodejs
 		if (typeof process === 'object' && process.env.DEBUG === 'true') {
 			console.log(body);
-		}
+		};
 
 		return fetch(api, {
 			method: 'POST',
@@ -59,15 +63,19 @@ const pageResults = ({ api, query: { entity, selection = {}, properties = [] }, 
 				} = json;
 
 				// stop if we are on the last page
-				if (results.length < pageSize || Math.min(max, skip + results.length) >= max) {
+				if (results.length < pageSize || results.length >= max) {
+					if(results.length >= max) {
+						return results.slice(0, max);
+					}
+
 					return results;
 				}
 
-				return runner({ skip: skip + pageSize }).then(newResults => results.concat(newResults));
+				return runner({ lastId: results[results.length-1].id }).then(newResults => results.concat(newResults));
 			});
 	};
 
-	return runner({ skip: 0 });
+	return runner({ lastId: undefined });
 };
 
 module.exports = pageResults;


### PR DESCRIPTION
As of yesterday (19.2.2021) TheGraph reduced the maximum number by which you can skip to 5000. 

I've implemented the solution recommended by TheGraph - [https://thegraph.com/docs/graphql-api](https://thegraph.com/docs/graphql-api)